### PR TITLE
Minor cosmetic change plus update to the README and example files

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -37,13 +37,13 @@ string teststr(
 istringstream input(teststr);
 Object o;
 assert(o.parse(input));
-assert(1 == o.get<long>("foo"));
+assert(1 == o.get<jsonxx::number>("foo"));
 assert(o.has<bool>("bar"));
 assert(o.has<Object>("person"));
-assert(o.get<Object>("person").has<long>("age"));
+assert(o.get<Object>("person").has<jsonxx::number>("age"));
 assert(o.has<Array>("data"));
-assert(o.get<Array>("data").get<long>(1) == 42);
+assert(o.get<Array>("data").get<jsonxx::number>(1) == 42);
 assert(o.get<Array>("data").get<string>(0) == "abcd");
-assert(!o.has<long>("data"));
+assert(!o.has<jsonxx::number>("data"));
 </code>
 </pre>

--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -11,6 +11,10 @@
 
 namespace jsonxx {
 
+bool match(const char* pattern, std::istream& input);
+bool parse_string(std::istream& input, std::string* value);
+bool parse_number(std::istream& input, number* value);
+
 // Try to consume characters from the input stream and match the
 // pattern string.
 bool match(const char* pattern, std::istream& input) {
@@ -82,7 +86,7 @@ bool parse_string(std::istream& input, std::string* value) {
     }
 }
 
-bool parse_bool(std::istream& input, bool* value) {
+static bool parse_bool(std::istream& input, bool* value) {
     if (match("true", input))  {
         *value = true;
         return true;
@@ -94,14 +98,14 @@ bool parse_bool(std::istream& input, bool* value) {
     return false;
 }
 
-bool parse_null(std::istream& input) {
+static bool parse_null(std::istream& input) {
     if (match("null", input))  {
         return true;
     }
     return false;
 }
 
-bool parse_number(std::istream& input, double* value) {
+bool parse_number(std::istream& input, number* value) {
     input >> std::ws;
     input >> *value;
     if (input.fail()) {
@@ -286,8 +290,8 @@ static std::ostream& stream_string(std::ostream& stream,
 }  // namespace jsonxx
 
 std::ostream& operator<<(std::ostream& stream, const jsonxx::Value& v) {
-    if (v.is<double>()) {
-        return stream << v.get<double>();
+    if (v.is<jsonxx::number>()) {
+        return stream << v.get<jsonxx::number>();
     } else if (v.is<std::string>()) {
         return jsonxx::stream_string(stream, v.get<std::string>());
     } else if (v.is<bool>()) {

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -11,6 +11,8 @@
 
 namespace jsonxx {
 
+typedef double number;
+	
 class Value;
 
 // A JSON Object
@@ -48,7 +50,7 @@ class Array {
 
   static bool parse(std::istream& input, Array& array);
 
-  unsigned int size() const { return values_.size(); }
+  size_t size() const { return values_.size(); }
 
   template <typename T>
   bool has(unsigned int i) const;
@@ -99,7 +101,7 @@ class Value {
     INVALID_
   } type_;
   union {
-    double number_value_;
+    number number_value_;
     std::string* string_value_;
     bool bool_value_;
     Array* array_value_;
@@ -165,7 +167,7 @@ inline bool Value::is<std::string>() const {
 }
 
 template<>
-inline bool Value::is<double>() const {
+inline bool Value::is<number>() const {
   return type_ == NUMBER_;
 }
 
@@ -192,8 +194,8 @@ inline std::string& Value::get<std::string>() {
 }
 
 template<>
-inline double& Value::get<double>() {
-  assert(is<double>());
+inline number& Value::get<number>() {
+  assert(is<number>());
   return number_value_;
 }
 
@@ -222,8 +224,8 @@ inline const std::string& Value::get<std::string>() const {
 }
 
 template<>
-inline const double& Value::get<double>() const {
-  assert(is<double>());
+inline const number& Value::get<number>() const {
+  assert(is<number>());
   return number_value_;
 }
 

--- a/jsonxx_test.cc
+++ b/jsonxx_test.cc
@@ -9,9 +9,9 @@
 #include "jsonxx.h"
 
 namespace jsonxx {
-bool parse_string(std::istream& input, std::string* value);
-bool parse_number(std::istream& input, double* value);
-bool match(const char* pattern, std::istream& input);
+extern bool parse_string(std::istream& input, std::string* value);
+extern bool parse_number(std::istream& input, number* value);
+extern bool match(const char* pattern, std::istream& input);
 }
 
 int main() {
@@ -41,7 +41,7 @@ int main() {
     {
         string teststr("6");
         istringstream input(teststr);
-        double value;
+        number value;
         assert(parse_number(input, &value));
         assert(value == 6);
     }
@@ -67,24 +67,24 @@ int main() {
         istringstream input(teststr);
         Value v;
         assert(Value::parse(input, v));
-        assert(v.is<double>());
-        assert(v.get<double>() == 6);
+        assert(v.is<number>());
+        assert(v.get<number>() == 6);
     }
     {
         string teststr("+6");
         istringstream input(teststr);
         Value v;
         assert(Value::parse(input, v));
-        assert(v.is<double>());
-        assert(v.get<double>() == 6);
+        assert(v.is<number>());
+        assert(v.get<number>() == 6);
     }
     {
         string teststr("-6");
         istringstream input(teststr);
         Value v;
         assert(Value::parse(input, v));
-        assert(v.is<double>());
-        assert(v.get<double>() == -6);
+        assert(v.is<number>());
+        assert(v.get<number>() == -6);
     }
     {
         string teststr("asdf");
@@ -134,8 +134,8 @@ int main() {
         assert(Array::parse(input, a));
         assert(a.has<std::string>(0));
         assert("field1" == a.get<std::string>(0));
-        assert(a.has<double>(1));
-        assert(6 == a.get<double>(1));
+        assert(a.has<number>(1));
+        assert(6 == a.get<number>(1));
         assert(!a.has<bool>(2));
     }
     {
@@ -150,15 +150,15 @@ int main() {
         istringstream input(teststr);
         Object o;
         assert(Object::parse(input, o));
-        assert(1 == o.get<double>("foo"));
+        assert(1 == o.get<number>("foo"));
         assert(o.has<bool>("bar"));
         assert(o.has<Object>("person"));
-        assert(o.get<Object>("person").has<double>("age"));
+        assert(o.get<Object>("person").has<number>("age"));
         assert(o.has<Array>("data"));
-        assert(o.get<Array>("data").get<double>(1) == 42);
+        assert(o.get<Array>("data").get<number>(1) == 42);
         assert(o.get<Array>("data").get<string>(0) == "abcd");
-        assert(o.get<Array>("data").get<double>(2) == 54.7);
-        assert(!o.has<double>("data"));
+        assert(o.get<Array>("data").get<number>(2) == 54.7);
+        assert(!o.has<number>("data"));
     }
     {
         string teststr("{\"bar\": \"a\\rb\\nc\\td\", \"foo\": true}");


### PR DESCRIPTION
- Added the "number" datatype as specified by RFC-4627 (minor cosmetic change)
- Updated example program plus README file so they make use of the jsonxx::number datatype.
- Added some function prototypes for the parse_*\* functions so we get less warnings during compilation
