### PR TITLE
Fix a compiler error

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -782,7 +782,7 @@ std::string Object::json() const {
     v.object_value_ = const_cast<jsonxx::Object*>(this);
     v.type_ = jsonxx::Value::OBJECT_;
 
-    std::string result = tag( jsonxx::JSON, 0, std::string(), v, std::string() );
+    std::string result = tag( jsonxx::JSON, 0, std::string(), v );
 
     v.object_value_ = 0;
     return remove_last_comma( result );
@@ -809,7 +809,7 @@ std::string Array::json() const {
     v.array_value_ = const_cast<jsonxx::Array*>(this);
     v.type_ = jsonxx::Value::ARRAY_;
 
-    std::string result = tag( jsonxx::JSON, 0, std::string(), v, std::string() );
+    std::string result = tag( jsonxx::JSON, 0, std::string(), v );
 
     v.array_value_ = 0;
     return remove_last_comma( result );


### PR DESCRIPTION
So I realised where that attr parameter was used but they were actually default constructed strings so they really did have no use. I removed them to prevent a compilation error (oops :( ). I have triple checked that this compiles now so it should be good.

One thing I noticed is that there is a lot of duplication of code for integral types using a macro. Would fixing that be desirable? Because if so then I wouldn't mind fixing that using the current `JSONXX_COMPILER_HAS_CXX11` macro to detect C++11 and some slight (portable) template metaprogramming.
