### PR TITLE
Implement rollback for number parsing.

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -183,9 +183,11 @@ bool parse_identifier(std::istream& input, String& value) {
 
 bool parse_number(std::istream& input, Number& value) {
     input >> std::ws;
+    std::streampos rollback = input.tellg();
     input >> value;
     if (input.fail()) {
         input.clear();
+        input.seekg(rollback);
         return false;
     }
     return true;


### PR DESCRIPTION
The stream number parser was parsing the initial two letters of a binary value of 'false' as hexadecimal input. After failing number parsing on 'l', the stream was not rolled back and subsequent parsing failed.

This occurs on Mac OS X using Apple LLVM version 5.0 (Apple Clang 5.0).

The only thing that concerns me about this new code is that it won't work for streams that don't implement seekg. In my case, stringstream, it is implemented. I've tested it on a number of json files on Mac OS X with libc++, but the test json files are by no means not exhaustive.
