### PR TITLE
Fix Unicode Character parsing

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -118,7 +118,7 @@ bool parse_string(std::istream& input, String& value) {
                         std::stringstream ss;
                         for( i = 0; (!input.eof() && input.good()) && i < 4; ++i ) {
                             input.get(ch);
-                            ss << ch;
+                            ss << std::hex << ch;
                         }
                         if( input.good() && (ss >> i) )
                             value.push_back(i);


### PR DESCRIPTION
Unicode characters are in hex, not decimal. Not sure how that ever worked :stuck_out_tongue: 
