### PR TITLE
Suppress Visual Studio C4244 data loss warning with explicit static cast

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -121,7 +121,7 @@ bool parse_string(std::istream& input, String& value) {
                             ss << std::hex << ch;
                         }
                         if( input.good() && (ss >> i) )
-                            value.push_back(i);
+                            value.push_back(static_cast<char>(i));
                     }
                     break;
                 default:


### PR DESCRIPTION
Without the explicit static cast Visual Studio quite rightly warns about data loss:

```
jsonxx\jsonxx.cc(124): warning C4244: 'argument' : conversion from 'int' to 'char', possible loss of data
```
