### PR TITLE
Suppress the C4127 Visual Studio warning

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -77,7 +77,7 @@ bool match(const char* pattern, std::istream& input) {
 bool parse_string(std::istream& input, String& value) {
     char ch = '\0', delimiter = '"';
     if (!match("\"", input))  {
-        if (Parser == Strict) {
+        if (parser_is_strict()) {
             return false;
         }
         delimiter = '\'';
@@ -209,7 +209,7 @@ bool parse_null(std::istream& input) {
     if (match("null", input))  {
         return true;
     }
-    if (Parser == Strict) {
+    if (parser_is_strict()) {
         return false;
     }
     return (input.peek()==',');
@@ -224,7 +224,7 @@ bool parse_object(std::istream& input, Object& object) {
 }
 
 bool parse_comment(std::istream &input) {
-    if( Parser == Permissive )
+    if( parser_is_permissive() )
     if( !input.eof() && input.peek() == '/' )
     {
         char ch0(0);
@@ -281,9 +281,9 @@ bool Object::parse(std::istream& input, Object& object) {
 
     do {
         std::string key;
-        if(UnquotedKeys == Enabled) {
+        if (unquoted_keys_are_enabled()) {
             if (!parse_identifier(input, key)) {
-                if (Parser == Permissive) {
+                if (parser_is_permissive()) {
                     if (input.peek() == '}')
                         break;
                 }
@@ -292,7 +292,7 @@ bool Object::parse(std::istream& input, Object& object) {
         }
         else {
             if (!parse_string(input, key)) {
-                if (Parser == Permissive) {
+                if (parser_is_permissive()) {
                     if (input.peek() == '}')
                         break;
                 }

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -32,8 +32,21 @@
 #define JSONXX_COMPILER_HAS_CXX11 0
 #endif
 
+#ifdef _MSC_VER
+// disable the C4127 warning if using VC, see http://stackoverflow.com/a/12042515
+#define JSONXX_ASSERT(...) \
+  do { \
+    __pragma(warning(push)) __pragma(warning(disable:4127)) \
+    if( jsonxx::Assertions ) \
+    __pragma(warning(pop)) \
+      jsonxx::assertion(__FILE__,__LINE__,#__VA_ARGS__,bool(__VA_ARGS__)); \
+  __pragma(warning(push)) __pragma(warning(disable:4127)) \
+  } while(0) \
+  __pragma(warning(pop))
+#else
 #define JSONXX_ASSERT(...) do { if( jsonxx::Assertions ) \
   jsonxx::assertion(__FILE__,__LINE__,#__VA_ARGS__,bool(__VA_ARGS__)); } while(0)
+#endif
 
 namespace jsonxx {
 
@@ -49,6 +62,17 @@ enum Settings {
   UnquotedKeys = Disabled, // support of unquoted keys
   Assertions = Enabled  // enabled or disabled assertions (these asserts work both in DEBUG and RELEASE builds)
 };
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4127)
+#endif
+inline bool parser_is_strict() { return Parser == Strict; }
+inline bool parser_is_permissive() { return Parser == Permissive; }
+inline bool unquoted_keys_are_enabled() { return UnquotedKeys == Enabled; }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 // Constants for .write() and .xml() methods
 enum Format {


### PR DESCRIPTION
See http://stackoverflow.com/questions/12042433/how-to-disable-c4127-for-do-whilefalse and the answer http://stackoverflow.com/a/12042515 for problem description.

Wrapped inside `#ifdef _MSC_VER`, so the patch does not affect other compilers.
