### PR TITLE
Add workaround for Apple C++ compilers and C++11

### DIFF
--- a/jsonxx.h
+++ b/jsonxx.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cassert>
 #include <iostream>
 #include <map>


### PR DESCRIPTION
uname -v: <code>Darwin Kernel Version 12.5.0: Sun Sep 29 13:33:47 PDT 2013; root:xnu-2050.48.12~1/RELEASE_X86_64</code>
gcc:
<pre>Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)
Target: x86_64-apple-darwin12.5.0
Thread model: posix
</pre>

Building with OSX Mountain Lion using different c++ flags causes some build issues that require declaring nullptr_t, even though 'nullptr' exists. The proposed change will declare nullptr_t if it is supportable by the compiler, allowing jsonxx to work with the odd situation Apple system compilers present.

<pre>
~/repos/jsonxx % make
c++ -Werror -Wall -g -std=c++11   -c -o jsonxx.o jsonxx.cc
In file included from jsonxx.cc:8:
./jsonxx.h:222:27: error: no type named 'nullptr_t' in namespace 'std'
  void import( const std::nullptr_t & ) {
                     ~~~~~^
jsonxx.cc:1032:28: error: no viable conversion from 'const jsonxx::Object' to 'const jsonxx::Value'
  import( std::string(odd),value);
                           ^~~~~
./jsonxx.h:287:3: note: candidate constructor [with T = jsonxx::Object]
  Value( const T&t ) : type_(INVALID_) { import(t); }
  ^
./jsonxx.h:285:3: note: candidate constructor not viable: no known conversion from 'const jsonxx::Object' to 'const jsonxx::Value &' for 1st argument
  Value(const Value &other);
  ^
./jsonxx.h:289:3: note: candidate template ignored: failed template argument deduction
  Value( const char (&t)[N] ) : type_(INVALID_) { import( std::string(t) ); }
  ^
jsonxx.cc:1006:59: note: passing argument to parameter 'value' here
void Object::import( const std::string &key, const Value &value ) {
                                                          ^
2 errors generated.
make: *** [jsonxx.o] Error 1
</pre>