### PR TITLE
Implement a method to append arrays to arrays

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -168,7 +168,7 @@ bool parse_identifier(std::istream& input, String& value) {
             (ch >= 'a' && ch <= 'z') ||
             (ch >= 'A' && ch <= 'Z') ||
             (ch >= '0' && ch <= '9')) {
-            value.push_back(ch);            
+            value.push_back(ch);
         }
         else if(ch == '\t' || ch == ' ') {
             input >> std::ws;
@@ -1066,6 +1066,13 @@ Array::Array(const Array &other) {
 }
 Array::Array(const Value &value) {
   import(value);
+}
+void Array::append(const Array &other) {
+    if (this != &other) {
+        values_.push_back( new Value(other) );
+    } else {
+        append( Array(*this) );
+    }
 }
 void Array::import(const Array &other) {
   if (this != &other) {

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -166,6 +166,8 @@ class Array {
   bool parse(std::istream &input);
   bool parse(const std::string &input);
   typedef std::vector<Value*> container;
+  void append(const Array &other);
+  void append(const Value &value) { import(value); }
   void import(const Array &other);
   void import(const Value &value);
   Array &operator<<(const Array &other);
@@ -382,7 +384,7 @@ const T& Object::get(const std::string& key, const typename identity<T>::type& d
     return default_value;
   }
 }
-    
+
 template<>
 inline bool Value::is<Value>() const {
     return true;
@@ -417,12 +419,12 @@ template<>
 inline bool Value::is<Object>() const {
   return type_ == OBJECT_;
 }
-    
+
 template<>
 inline Value& Value::get<Value>() {
     return *this;
 }
-    
+
 template<>
 inline const Value& Value::get<Value>() const {
     return *this;


### PR DESCRIPTION
`Array::operator<<` currently appends each value of its operand to the current array - for example, this produces `[0]`, not `[[0]]`:

``` cpp
    Array a;
    Array b;
    b << 0;
    a << b;
```

I assume this is intentional, but I was unable to find a way to create nested arrays so I implemented `append()`, which functions much like `import()` (and calls `import()` for non-array values). `operator<<` could be changed to use it as well, but I'll leave it as-is since arguments could be made for either behavior.
