### PR TITLE
Added ability to override merging when pushing arrays into arrays

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -1067,14 +1067,21 @@ Array::Array(const Array &other) {
 Array::Array(const Value &value) {
   import(value);
 }
-void Array::import(const Array &other) {
+void Array::import(const Array &other, const bool merge) {
   if (this != &other) {
     // default
-    container::const_iterator
+    if (merge)
+    {
+      container::const_iterator
         it = other.values_.begin(),
         end = other.values_.end();
-    for (/**/ ; it != end; ++it) {
-      values_.push_back( new Value(**it) );
+      for (/**/ ; it != end; ++it) {
+        values_.push_back( new Value(**it) );
+      }
+    }
+    else
+    {
+      values_.push_back( new Value(other) );
     }
   } else {
     // recursion is supported here

--- a/jsonxx.h
+++ b/jsonxx.h
@@ -166,7 +166,7 @@ class Array {
   bool parse(std::istream &input);
   bool parse(const std::string &input);
   typedef std::vector<Value*> container;
-  void import(const Array &other);
+  void import(const Array &other, const bool merge = true);
   void import(const Value &value);
   Array &operator<<(const Array &other);
   Array &operator<<(const Value &value);


### PR DESCRIPTION
Currently, an `Array` pushed into another `Array` via `operator<<` will merge into the target `Array`. Sometimes (probably most of the time) we want the `Array` to become a child instead. The update is fully backwards-compatible, as it only adds a single optional param that defaults to the original behaviour.

To append a child `Array A`, instead of using `operator<<`, we call `import(A, false)`.
