### PR TITLE
Faulty json string causes memory leaks

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -307,6 +307,7 @@ bool Object::parse(std::istream& input, Object& object) {
             delete v;
             break;
         }
+        JSONXX_ASSERT(object.value_map_.find(key) == object.value_map_.end());
         object.value_map_[key] = v;
     } while (match(",", input));
 


### PR DESCRIPTION
In case key in map exists (caused by faulty json string) key's first value (Value-ptr) becomes overwritten by new Value *v causing memory leaks since original Value-ptr will never be deleted.
