### PR TITLE
Fix parsing from std::cin (tellg/seekg are not working for it).

### DIFF
--- a/jsonxx.cc
+++ b/jsonxx.cc
@@ -183,11 +183,9 @@ bool parse_identifier(std::istream& input, String& value) {
 
 bool parse_number(std::istream& input, Number& value) {
     input >> std::ws;
-    std::streampos rollback = input.tellg();
     input >> value;
     if (input.fail()) {
         input.clear();
-        input.seekg(rollback);
         return false;
     }
     return true;


### PR DESCRIPTION
Hi there,

I fixed parsing from std::cin.  The problem was in tellg/seekg that break std::cin (and it looks they are not required at all, so I removed them).

You can reproduce the issue with the following sample:

```cpp
#include "jsonxx.h"
#include <iostream>

using namespace std;
using namespace jsonxx;

int main()
{
    Object o;
    o.parse(cin);
    cout << o.get<Array>("ar").get<Number>(0) << endl;
    return 0;
}
```

Send this json to stdin:
```js
{ "ar" : [1] }
```